### PR TITLE
fix: ECDH with null length

### DIFF
--- a/src/mechs/ec/crypto.ts
+++ b/src/mechs/ec/crypto.ts
@@ -91,7 +91,7 @@ export class EcCrypto {
     return ok;
   }
 
-  public static async deriveBits(algorithm: EcdhKeyDeriveParams, baseKey: CryptoKey, length: number): Promise<ArrayBuffer> {
+  public static async deriveBits(algorithm: EcdhKeyDeriveParams, baseKey: CryptoKey, length: number | null): Promise<ArrayBuffer> {
     const cryptoAlg = this.getOpenSSLNamedCurve((baseKey.algorithm as EcKeyAlgorithm).namedCurve);
 
     const ecdh = crypto.createECDH(cryptoAlg);
@@ -101,6 +101,10 @@ export class EcCrypto {
 
     const asnPublicKey = AsnParser.parse((algorithm.public as CryptoKey).data, core.asn1.PublicKeyInfo);
     const bits = ecdh.computeSecret(Buffer.from(asnPublicKey.publicKey));
+
+    if (length === null) {
+      return bits;
+    }
 
     return new Uint8Array(bits).buffer.slice(0, length >> 3);
   }

--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -280,4 +280,23 @@ context("Crypto", () => {
     });
   });
 
+  context("ECDH deriveBits with null", () => {
+    it("P-256", async () => {
+      const keyPair = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
+      const bits = await crypto.subtle.deriveBits({ name: keyPair.publicKey.algorithm.name, public: keyPair.publicKey } as globalThis.EcdhKeyDeriveParams, keyPair.privateKey, <number><unknown>null);
+      assert.equal(bits.byteLength, 32);
+    });
+
+    it("P-384", async () => {
+      const keyPair = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-384" }, false, ["deriveBits"]);
+      const bits = await crypto.subtle.deriveBits({ name: keyPair.publicKey.algorithm.name, public: keyPair.publicKey } as globalThis.EcdhKeyDeriveParams, keyPair.privateKey, <number><unknown>null);
+      assert.equal(bits.byteLength, 48);
+    });
+
+    it("P-521", async () => {
+      const keyPair = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-521" }, false, ["deriveBits"]);
+      const bits = await crypto.subtle.deriveBits({ name: keyPair.publicKey.algorithm.name, public: keyPair.publicKey } as globalThis.EcdhKeyDeriveParams, keyPair.privateKey, <number><unknown>null);
+      assert.equal(bits.byteLength, 66);
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes the ECDH deriveBits op when `null` is passed as length. This behaviour is covered by [Web Platform Tests](https://github.com/web-platform-tests/wpt/blob/3174b85610804424ac4c6c2a194a08220402a00e/WebCryptoAPI/derive_bits_keys/ecdh_bits.js#L58-L66).

The global DOM types will get [updated](https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1416) as soon as the spec bug around actually passing `null` as length gets [fixed](https://github.com/w3c/webcrypto/issues/322).