### PR TITLE
fix: import Buffer before use

### DIFF
--- a/src/converters/base64_url.ts
+++ b/src/converters/base64_url.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { IJsonConverter } from "@peculiar/json-schema";
 import { Convert } from "pvtsutils";
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import * as core from "webcrypto-core";
 import { SubtleCrypto } from "./subtle";

--- a/src/keys/key.ts
+++ b/src/keys/key.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { JsonProp, JsonPropTypes } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";
 

--- a/src/mechs/aes/aes_cmac.ts
+++ b/src/mechs/aes/aes_cmac.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import * as crypto from "crypto";
 import * as core from "webcrypto-core";
 import { AesCrypto } from "./crypto";

--- a/src/mechs/aes/crypto.ts
+++ b/src/mechs/aes/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto, { CipherGCM, DecipherGCM } from "crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/aes/key.ts
+++ b/src/mechs/aes/key.ts
@@ -1,3 +1,4 @@
+import type { Buffer } from "buffer";
 import { JsonProp } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";
 import { JsonBase64UrlConverter } from "../../converters";

--- a/src/mechs/des/crypto.ts
+++ b/src/mechs/des/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/des/key.ts
+++ b/src/mechs/des/key.ts
@@ -1,3 +1,4 @@
+import type { Buffer } from "buffer";
 import { JsonProp } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";
 import { JsonBase64UrlConverter } from "../../converters";

--- a/src/mechs/ec/crypto.ts
+++ b/src/mechs/ec/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";

--- a/src/mechs/ec/private_key.ts
+++ b/src/mechs/ec/private_key.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { IJsonConvertible, JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/ed/crypto.ts
+++ b/src/mechs/ed/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import { AsnParser } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
@@ -141,14 +142,14 @@ export class EdCrypto {
       crv: algorithm.namedCurve,
       d: Convert.ToBase64Url(asnKey.d),
     });
-    
+
     key.algorithm = Object.assign({}, algorithm) as EcKeyAlgorithm;
     key.extractable = extractable;
     key.usages = keyUsages;
-    
+
     return key;
   }
-  
+
   protected static async importPublicKey(asnKey: ArrayBuffer, algorithm: EcKeyImportParams, extractable: boolean, keyUsages: KeyUsage[]) {
     const key = new EdPublicKey();
     key.fromJSON({

--- a/src/mechs/ed/private_key.ts
+++ b/src/mechs/ed/private_key.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { IJsonConvertible, JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/ed/public_key.ts
+++ b/src/mechs/ed/public_key.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { IJsonConvertible } from "@peculiar/json-schema";
 import { Convert } from "pvtsutils";

--- a/src/mechs/hkdf/hkdf.ts
+++ b/src/mechs/hkdf/hkdf.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import * as core from "webcrypto-core";
 import { BufferSourceConverter, CryptoKey } from "webcrypto-core";

--- a/src/mechs/hkdf/key.ts
+++ b/src/mechs/hkdf/key.ts
@@ -1,3 +1,4 @@
+import type { Buffer } from "buffer";
 import { CryptoKey } from "../../keys";
 
 export class HkdfCryptoKey extends CryptoKey {

--- a/src/mechs/hmac/hmac.ts
+++ b/src/mechs/hmac/hmac.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/hmac/key.ts
+++ b/src/mechs/hmac/key.ts
@@ -1,3 +1,4 @@
+import type { Buffer } from "buffer";
 import { JsonProp } from "@peculiar/json-schema";
 import { JsonBase64UrlConverter } from "../../converters";
 import { CryptoKey } from "../../keys";

--- a/src/mechs/pbkdf/pbkdf2.ts
+++ b/src/mechs/pbkdf/pbkdf2.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import * as core from "webcrypto-core";
 import { PbkdfCryptoKey } from "./key";

--- a/src/mechs/rsa/crypto.ts
+++ b/src/mechs/rsa/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";

--- a/src/mechs/rsa/private_key.ts
+++ b/src/mechs/rsa/private_key.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/rsa/public_key.ts
+++ b/src/mechs/rsa/public_key.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";

--- a/src/mechs/rsa/rsa_oaep.ts
+++ b/src/mechs/rsa/rsa_oaep.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import * as core from "webcrypto-core";
 import { RsaCrypto } from "./crypto";

--- a/src/mechs/sha/crypto.ts
+++ b/src/mechs/sha/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 
 export class ShaCrypto {

--- a/src/mechs/shake/crypto.ts
+++ b/src/mechs/shake/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import crypto from "crypto";
 import * as core from "webcrypto-core";
 

--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import assert from "node:assert";
 import nodeCrypto from "node:crypto";
 import process from "node:process";


### PR DESCRIPTION
Importing node's `Buffer` class before use makes bundling apps simpler because when your target is an environment that doesn't have a `Buffer` global, you don't have to ensure you've mutated the `global` object to add `Buffer` support before `@peculiar/webcrypto` is loaded - you can just do it by configuring the module resolver with a polyfill instead and let the user load modules in whatever order they want.

This makes bundling react-native apps a bit simpler.