### PR TITLE
fix: pass tag length for aes decipher

### DIFF
--- a/src/mechs/aes/crypto.ts
+++ b/src/mechs/aes/crypto.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import crypto, { CipherGCM, DecipherGCM } from "crypto";
+import crypto, {  CipherGCMTypes } from "crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
 import * as core from "webcrypto-core";
 import { AesCryptoKey } from "./key";
@@ -136,9 +136,9 @@ export class AesCrypto {
   }
 
   public static async encryptAesGCM(algorithm: AesGcmParams, key: AesCryptoKey, data: Buffer) {
-    const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-gcm`, key.data, Buffer.from(algorithm.iv as ArrayBuffer), {
+    const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-gcm` as CipherGCMTypes, key.data, Buffer.from(algorithm.iv as ArrayBuffer), {
       authTagLength: (algorithm.tagLength || 128) >> 3,
-    } as any) as CipherGCM; // NodeJs d.ts doesn't support CipherGCMOptions for createCipheriv
+    }); // NodeJs d.ts doesn't support CipherGCMOptions for createCipheriv
     if (algorithm.additionalData) {
       cipher.setAAD(Buffer.from(algorithm.additionalData as ArrayBuffer));
     }
@@ -149,8 +149,10 @@ export class AesCrypto {
   }
 
   public static async decryptAesGCM(algorithm: AesGcmParams, key: AesCryptoKey, data: Buffer) {
-    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-gcm`, key.data, new Uint8Array(algorithm.iv as ArrayBuffer)) as DecipherGCM;
     const tagLength = (algorithm.tagLength || 128) >> 3;
+    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-gcm` as CipherGCMTypes, key.data, new Uint8Array(algorithm.iv as ArrayBuffer), {
+      authTagLength: tagLength,
+    });
     const enc = data.slice(0, data.length - tagLength);
     const tag = data.slice(data.length - tagLength);
     if (algorithm.additionalData) {


### PR DESCRIPTION
Passed the authTagLength for [createDecipheriv](https://nodejs.org/api/crypto.html#cryptocreatedecipherivalgorithm-key-iv-options)

Decryption for AES GCM requires passing the correct tag length otherwise `decipher.setTagLength()` will throw. See [node docs](https://nodejs.org/api/crypto.html#deciphersetauthtagbuffer-encoding):

> If the tag length is invalid according to [NIST SP 800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf) or does not match the value of the authTagLength option, decipher.setAuthTag() will throw an error.

Fixed a couple of type casts as well