### PR TITLE
fix: react native by resolving esm and removing crypto namespace imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "main": "build/webcrypto.js",
   "module": "build/webcrypto.es.js",
+  "react-native": "build/webcrypto.es.js",
   "types": "index.d.ts",
   "scripts": {
     "test": "mocha",

--- a/src/mechs/aes/aes_cmac.ts
+++ b/src/mechs/aes/aes_cmac.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import * as crypto from "crypto";
+import crypto from "crypto";
 import * as core from "webcrypto-core";
 import { AesCrypto } from "./crypto";
 import { AesCryptoKey } from "./key";

--- a/src/mechs/rsa/rsa_es.ts
+++ b/src/mechs/rsa/rsa_es.ts
@@ -1,4 +1,4 @@
-import * as crypto from "crypto";
+import crypto from "crypto";
 import { Convert } from "pvtsutils";
 import * as core from "webcrypto-core";
 import { RsaCrypto } from "./crypto";

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -1,4 +1,4 @@
-import * as crypto from "crypto";
+import crypto from "crypto";
 import * as process from "process";
 import * as core from "webcrypto-core";
 import {


### PR DESCRIPTION
We're having issues with rollup's [_interopNamespaceDefault](https://rollupjs.org/configuration-options/#output-dynamicimportincjs) in cjs. This is the first time I've run into this issue and it seems to come from how Rollup handles resolving namespace imports in cjs. For the most part in react native we use esm translated to cjs via babel which configured properly won't have the same issues rollup is having serving the cjs bundle to us. Toward that end I have a two part fix to issues we're having in react native:

1. specify the esm bundle using package.json for "react-native"
2. when `crypto` is shimmed or aliased AND the namespace import is used this breaks dependency resolution, so I modified the `crypto` import to not be a namespace import

