### PR TITLE
chore: migrate to @peculiar/utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.6",
+        "@peculiar/utils": "^2.0.1",
         "tslib": "^2.8.1",
         "webcrypto-core": "^1.8.1"
       },
@@ -28,7 +28,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -500,6 +500,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-7f/uHXQ+YAKs3NtY0Yg8CwPdBqRWV9eu5C/tYU7hITzPHtYTksj4jbr3pmu2wzBitPIeLMCQuoHX2zv+9TARWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/webcrypto-test": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@peculiar/json-schema": "^1.1.12",
         "@peculiar/utils": "^2.0.1",
         "tslib": "^2.8.1",
-        "webcrypto-core": "^1.8.1"
+        "webcrypto-core": "^1.9.0"
       },
       "devDependencies": {
         "@peculiar/eslint-config-base": "^0.2.9",
@@ -5627,16 +5627,16 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.0.tgz",
+      "integrity": "sha512-ULMJZdRaACcQym3tuBEVcFHRfIbO2sbgBd2eIzo+KYk5eRk9wNxB8td9mX3mmAytLrtE4MRfYSwE1irSw1iGAg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.6.0",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
+        "@peculiar/utils": "^2.0.1",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@peculiar/json-schema": "^1.1.12",
     "@peculiar/utils": "^2.0.1",
     "tslib": "^2.8.1",
-    "webcrypto-core": "^1.8.1"
+    "webcrypto-core": "^1.9.0"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@peculiar/asn1-schema": "^2.6.0",
     "@peculiar/json-schema": "^1.1.12",
-    "pvtsutils": "^1.3.6",
+    "@peculiar/utils": "^2.0.1",
     "tslib": "^2.8.1",
     "webcrypto-core": "^1.8.1"
   },

--- a/src/converters/base64_url.ts
+++ b/src/converters/base64_url.ts
@@ -1,8 +1,8 @@
 import { Buffer } from "node:buffer";
 import { IJsonConverter } from "@peculiar/json-schema";
-import { Convert } from "pvtsutils";
+import { convert } from "@peculiar/utils";
 
 export const JsonBase64UrlConverter: IJsonConverter<Buffer, string> = {
-  fromJSON: (value: string) => Buffer.from(Convert.FromBase64Url(value)),
-  toJSON: (value: Buffer) => Convert.ToBase64Url(value),
+  fromJSON: (value: string) => Buffer.from(convert.decode("base64url", value)),
+  toJSON: (value: Buffer) => convert.encode("base64url", value),
 };

--- a/src/mechs/aes/crypto.ts
+++ b/src/mechs/aes/crypto.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer";
 import crypto, { CipherGCMTypes } from "node:crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
+import {
+  assertBufferSource, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { CryptoKey } from "../../keys";
 import { AesCryptoKey } from "./key";
@@ -27,7 +30,7 @@ export class AesCrypto {
       case "jwk":
         return JsonSerializer.toJSON(key);
       case "raw":
-        return new Uint8Array(key.data).buffer;
+        return toArrayBuffer(key.data);
       default:
         throw new core.OperationError("format: Must be 'jwk' or 'raw'");
     }
@@ -41,8 +44,9 @@ export class AesCrypto {
         key = JsonParser.fromJSON(keyData, { targetSchema: AesCryptoKey });
         break;
       case "raw":
+        assertBufferSource(keyData);
         key = new AesCryptoKey();
-        key.data = Buffer.from(keyData as ArrayBuffer);
+        key.data = Buffer.from(toUint8Array(keyData));
         break;
       default:
         throw new core.OperationError("format: Must be 'jwk' or 'raw'");
@@ -105,84 +109,84 @@ export class AesCrypto {
   }
 
   public static async encryptAesCBC(algorithm: AesCbcParams, key: AesCryptoKey, data: Buffer) {
-    const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-cbc`, key.data, new Uint8Array(algorithm.iv as ArrayBuffer));
+    const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-cbc`, key.data, toUint8Array(algorithm.iv));
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final()]);
-    const res = new Uint8Array(enc).buffer;
+    const res = toArrayBuffer(enc);
     return res;
   }
 
   public static async decryptAesCBC(algorithm: AesCbcParams, key: AesCryptoKey, data: Buffer) {
-    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-cbc`, key.data, new Uint8Array(algorithm.iv as ArrayBuffer));
+    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-cbc`, key.data, toUint8Array(algorithm.iv));
     let dec = decipher.update(data);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 
   public static async encryptAesCTR(algorithm: AesCtrParams, key: AesCryptoKey, data: Buffer) {
-    const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-ctr`, key.data, Buffer.from(algorithm.counter as ArrayBuffer));
+    const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-ctr`, key.data, Buffer.from(toUint8Array(algorithm.counter)));
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final()]);
-    const res = new Uint8Array(enc).buffer;
+    const res = toArrayBuffer(enc);
     return res;
   }
 
   public static async decryptAesCTR(algorithm: AesCtrParams, key: AesCryptoKey, data: Buffer) {
-    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-ctr`, key.data, new Uint8Array(algorithm.counter as ArrayBuffer));
+    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-ctr`, key.data, toUint8Array(algorithm.counter));
     let dec = decipher.update(data);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 
   public static async encryptAesGCM(algorithm: AesGcmParams, key: AesCryptoKey, data: Buffer) {
     const cipher = crypto.createCipheriv(
       `aes-${key.algorithm.length}-gcm` as CipherGCMTypes,
       key.data,
-      Buffer.from(algorithm.iv as ArrayBuffer),
+      Buffer.from(toUint8Array(algorithm.iv)),
       { authTagLength: (algorithm.tagLength || 128) >> 3 },
     ); // NodeJs d.ts doesn't support CipherGCMOptions for createCipheriv
     if (algorithm.additionalData) {
-      cipher.setAAD(Buffer.from(algorithm.additionalData as ArrayBuffer));
+      cipher.setAAD(Buffer.from(toUint8Array(algorithm.additionalData)));
     }
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final(), cipher.getAuthTag()]);
-    const res = new Uint8Array(enc).buffer;
+    const res = toArrayBuffer(enc);
     return res;
   }
 
   public static async decryptAesGCM(algorithm: AesGcmParams, key: AesCryptoKey, data: Buffer) {
     const tagLength = (algorithm.tagLength || 128) >> 3;
-    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-gcm` as CipherGCMTypes, key.data, new Uint8Array(algorithm.iv as ArrayBuffer), { authTagLength: tagLength });
+    const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-gcm` as CipherGCMTypes, key.data, toUint8Array(algorithm.iv), { authTagLength: tagLength });
     const enc = data.slice(0, data.length - tagLength);
     const tag = data.slice(data.length - tagLength);
     if (algorithm.additionalData) {
-      decipher.setAAD(Buffer.from(algorithm.additionalData as ArrayBuffer));
+      decipher.setAAD(Buffer.from(toUint8Array(algorithm.additionalData)));
     }
     decipher.setAuthTag(tag);
     let dec = decipher.update(enc);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 
   public static async encryptAesKW(algorithm: Algorithm, key: AesCryptoKey, data: Buffer) {
     const cipher = crypto.createCipheriv(`id-aes${key.algorithm.length}-wrap`, key.data, this.AES_KW_IV);
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final()]);
-    return new Uint8Array(enc).buffer;
+    return toArrayBuffer(enc);
   }
 
   public static async decryptAesKW(algorithm: Algorithm, key: AesCryptoKey, data: Buffer) {
     const decipher = crypto.createDecipheriv(`id-aes${key.algorithm.length}-wrap`, key.data, this.AES_KW_IV);
     let dec = decipher.update(data);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 
   public static async encryptAesECB(algorithm: Algorithm, key: AesCryptoKey, data: Buffer) {
     const cipher = crypto.createCipheriv(`aes-${key.algorithm.length}-ecb`, key.data, new Uint8Array(0));
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final()]);
-    const res = new Uint8Array(enc).buffer;
+    const res = toArrayBuffer(enc);
     return res;
   }
 
@@ -190,6 +194,6 @@ export class AesCrypto {
     const decipher = crypto.createDecipheriv(`aes-${key.algorithm.length}-ecb`, key.data, new Uint8Array(0));
     let dec = decipher.update(data);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 }

--- a/src/mechs/des/crypto.ts
+++ b/src/mechs/des/crypto.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
+import {
+  assertBufferSource, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { DesParams } from "webcrypto-core";
 import { CryptoKey } from "../../keys";
@@ -22,7 +25,7 @@ export class DesCrypto {
       case "jwk":
         return JsonSerializer.toJSON(key);
       case "raw":
-        return new Uint8Array(key.data).buffer;
+        return toArrayBuffer(key.data);
       default:
         throw new core.OperationError("format: Must be 'jwk' or 'raw'");
     }
@@ -36,8 +39,9 @@ export class DesCrypto {
         key = JsonParser.fromJSON(keyData, { targetSchema: DesCryptoKey });
         break;
       case "raw":
+        assertBufferSource(keyData);
         key = new DesCryptoKey();
-        key.data = Buffer.from(keyData as ArrayBuffer);
+        key.data = Buffer.from(toUint8Array(keyData));
         break;
       default:
         throw new core.OperationError("format: Must be 'jwk' or 'raw'");
@@ -77,32 +81,32 @@ export class DesCrypto {
   }
 
   public static async encryptDesCBC(algorithm: DesParams, key: DesCryptoKey, data: Buffer) {
-    const cipher = crypto.createCipheriv("des-cbc", key.data, new Uint8Array(algorithm.iv as ArrayBuffer));
+    const cipher = crypto.createCipheriv("des-cbc", key.data, toUint8Array(algorithm.iv));
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final()]);
-    const res = new Uint8Array(enc).buffer;
+    const res = toArrayBuffer(enc);
     return res;
   }
 
   public static async decryptDesCBC(algorithm: DesParams, key: DesCryptoKey, data: Buffer) {
-    const decipher = crypto.createDecipheriv("des-cbc", key.data, new Uint8Array(algorithm.iv as ArrayBuffer));
+    const decipher = crypto.createDecipheriv("des-cbc", key.data, toUint8Array(algorithm.iv));
     let dec = decipher.update(data);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 
   public static async encryptDesEDE3CBC(algorithm: DesParams, key: DesCryptoKey, data: Buffer) {
-    const cipher = crypto.createCipheriv("des-ede3-cbc", key.data, Buffer.from(algorithm.iv as ArrayBuffer));
+    const cipher = crypto.createCipheriv("des-ede3-cbc", key.data, Buffer.from(toUint8Array(algorithm.iv)));
     let enc = cipher.update(data);
     enc = Buffer.concat([enc, cipher.final()]);
-    const res = new Uint8Array(enc).buffer;
+    const res = toArrayBuffer(enc);
     return res;
   }
 
   public static async decryptDesEDE3CBC(algorithm: DesParams, key: DesCryptoKey, data: Buffer) {
-    const decipher = crypto.createDecipheriv("des-ede3-cbc", key.data, new Uint8Array(algorithm.iv as ArrayBuffer));
+    const decipher = crypto.createDecipheriv("des-ede3-cbc", key.data, toUint8Array(algorithm.iv));
     let dec = decipher.update(data);
     dec = Buffer.concat([dec, decipher.final()]);
-    return new Uint8Array(dec).buffer;
+    return toArrayBuffer(dec);
   }
 }

--- a/src/mechs/ec/crypto.ts
+++ b/src/mechs/ec/crypto.ts
@@ -2,7 +2,9 @@ import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
-import { BufferSourceConverter } from "pvtsutils";
+import {
+  assertBufferSource, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { CryptoKey } from "../../keys";
 import { ShaCrypto } from "../sha";
@@ -63,7 +65,7 @@ export class EcCrypto {
 
     const signatureRaw = core.EcUtils.encodeSignature(ecSignature, core.EcCurves.get(key.algorithm.namedCurve).size);
 
-    return BufferSourceConverter.toArrayBuffer(signatureRaw);
+    return toArrayBuffer(signatureRaw);
   }
 
   public static async verify(algorithm: EcdsaParams, key: EcPublicKey, signature: Uint8Array, data: Uint8Array): Promise<boolean> {
@@ -79,8 +81,8 @@ export class EcCrypto {
     const ecSignature = new core.asn1.EcDsaSignature();
     const namedCurve = core.EcCurves.get(key.algorithm.namedCurve);
     const signaturePoint = core.EcUtils.decodeSignature(signature, namedCurve.size);
-    ecSignature.r = BufferSourceConverter.toArrayBuffer(signaturePoint.r);
-    ecSignature.s = BufferSourceConverter.toArrayBuffer(signaturePoint.s);
+    ecSignature.r = toArrayBuffer(signaturePoint.r);
+    ecSignature.s = toArrayBuffer(signaturePoint.s);
 
     const ecSignatureRaw = Buffer.from(AsnSerializer.serialize(ecSignature));
     const ok = signer.verify(options, ecSignatureRaw);
@@ -99,10 +101,10 @@ export class EcCrypto {
     const bits = ecdh.computeSecret(Buffer.from(asnPublicKey.publicKey));
 
     if (length === null) {
-      return BufferSourceConverter.toArrayBuffer(bits);
+      return toArrayBuffer(bits);
     }
 
-    return new Uint8Array(bits).buffer.slice(0, length >> 3);
+    return toArrayBuffer(bits).slice(0, length >> 3);
   }
 
   public static async exportKey(format: KeyFormat, key: CryptoKey): Promise<JsonWebKey | ArrayBuffer> {
@@ -111,7 +113,7 @@ export class EcCrypto {
         return JsonSerializer.toJSON(key);
       case "pkcs8":
       case "spki":
-        return new Uint8Array(key.data).buffer;
+        return toArrayBuffer(key.data);
       case "raw": {
         const publicKeyInfo = AsnParser.parse(key.data, core.asn1.PublicKeyInfo);
         return publicKeyInfo.publicKey;
@@ -134,17 +136,20 @@ export class EcCrypto {
         }
       }
       case "raw": {
-        const asnKey = new core.asn1.EcPublicKey(keyData as ArrayBuffer);
+        assertBufferSource(keyData);
+        const asnKey = new core.asn1.EcPublicKey(toArrayBuffer(keyData));
         return this.importPublicKey(asnKey, algorithm, extractable, keyUsages);
       }
       case "spki": {
-        const keyInfo = AsnParser.parse(new Uint8Array(keyData as ArrayBuffer), core.asn1.PublicKeyInfo);
+        assertBufferSource(keyData);
+        const keyInfo = AsnParser.parse(toUint8Array(keyData), core.asn1.PublicKeyInfo);
         const asnKey = new core.asn1.EcPublicKey(keyInfo.publicKey);
         this.assertKeyParameters(keyInfo.publicKeyAlgorithm.parameters, algorithm.namedCurve);
         return this.importPublicKey(asnKey, algorithm, extractable, keyUsages);
       }
       case "pkcs8": {
-        const keyInfo = AsnParser.parse(new Uint8Array(keyData as ArrayBuffer), core.asn1.PrivateKeyInfo);
+        assertBufferSource(keyData);
+        const keyInfo = AsnParser.parse(toUint8Array(keyData), core.asn1.PrivateKeyInfo);
         const asnKey = AsnParser.parse(keyInfo.privateKey, core.asn1.EcPrivateKey);
         this.assertKeyParameters(keyInfo.privateKeyAlgorithm.parameters, algorithm.namedCurve);
         return this.importPrivateKey(asnKey, algorithm, extractable, keyUsages);

--- a/src/mechs/ed/crypto.ts
+++ b/src/mechs/ed/crypto.ts
@@ -2,7 +2,9 @@ import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import { AsnParser } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
-import { Convert } from "pvtsutils";
+import {
+  assertBufferSource, convert, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { CryptoKey } from "../../keys";
 import { EdPrivateKey } from "./private_key";
@@ -53,7 +55,7 @@ export class EdCrypto {
     const options = { key: key.pem };
     const signature = crypto.sign(null, Buffer.from(data), options);
 
-    return core.BufferSourceConverter.toArrayBuffer(signature);
+    return toArrayBuffer(signature);
   }
 
   public static async verify(algorithm: EcdsaParams, key: EdPublicKey, signature: Uint8Array, data: Uint8Array): Promise<boolean> {
@@ -81,7 +83,7 @@ export class EdCrypto {
       privateKey,
     });
 
-    return new Uint8Array(bits).buffer.slice(0, length >> 3);
+    return toArrayBuffer(bits).slice(0, length >> 3);
   }
 
   public static async exportKey(format: KeyFormat, key: CryptoKey): Promise<JsonWebKey | ArrayBuffer> {
@@ -90,7 +92,7 @@ export class EdCrypto {
         return JsonSerializer.toJSON(key);
       case "pkcs8":
       case "spki":
-        return new Uint8Array(key.data).buffer;
+        return toArrayBuffer(key.data);
       case "raw": {
         const publicKeyInfo = AsnParser.parse(key.data, core.asn1.PublicKeyInfo);
         return publicKeyInfo.publicKey;
@@ -111,18 +113,21 @@ export class EdCrypto {
           if (!jwk.x) {
             throw new TypeError("keyData: Cannot get required 'x' filed");
           }
-          return this.importPublicKey(Convert.FromBase64Url(jwk.x), algorithm, extractable, keyUsages);
+          return this.importPublicKey(toArrayBuffer(convert.decode("base64url", jwk.x)), algorithm, extractable, keyUsages);
         }
       }
       case "raw": {
-        return this.importPublicKey(keyData as ArrayBuffer, algorithm, extractable, keyUsages);
+        assertBufferSource(keyData);
+        return this.importPublicKey(toArrayBuffer(keyData), algorithm, extractable, keyUsages);
       }
       case "spki": {
-        const keyInfo = AsnParser.parse(new Uint8Array(keyData as ArrayBuffer), core.asn1.PublicKeyInfo);
+        assertBufferSource(keyData);
+        const keyInfo = AsnParser.parse(toUint8Array(keyData), core.asn1.PublicKeyInfo);
         return this.importPublicKey(keyInfo.publicKey, algorithm, extractable, keyUsages);
       }
       case "pkcs8": {
-        const keyInfo = AsnParser.parse(new Uint8Array(keyData as ArrayBuffer), core.asn1.PrivateKeyInfo);
+        assertBufferSource(keyData);
+        const keyInfo = AsnParser.parse(toUint8Array(keyData), core.asn1.PrivateKeyInfo);
         const asnKey = AsnParser.parse(keyInfo.privateKey, core.asn1.CurvePrivateKey);
         return this.importPrivateKey(asnKey, algorithm, extractable, keyUsages);
       }
@@ -135,7 +140,7 @@ export class EdCrypto {
     const key = new EdPrivateKey();
     key.fromJSON({
       crv: algorithm.namedCurve,
-      d: Convert.ToBase64Url(asnKey.d),
+      d: convert.encode("base64url", asnKey.d),
     });
 
     key.algorithm = Object.assign({}, algorithm) as EcKeyAlgorithm;
@@ -149,7 +154,7 @@ export class EdCrypto {
     const key = new EdPublicKey();
     key.fromJSON({
       crv: algorithm.namedCurve,
-      x: Convert.ToBase64Url(asnKey),
+      x: convert.encode("base64url", asnKey),
     });
 
     key.algorithm = Object.assign({}, algorithm) as EcKeyAlgorithm;

--- a/src/mechs/ed/public_key.ts
+++ b/src/mechs/ed/public_key.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { IJsonConvertible } from "@peculiar/json-schema";
-import { Convert } from "pvtsutils";
+import { convert, toArrayBuffer } from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { AsymmetricKey } from "../../keys/asymmetric";
 import { getOidByNamedCurve } from "./helper";
@@ -25,7 +25,7 @@ export class EdPublicKey extends AsymmetricKey implements IJsonConvertible {
       ext: this.extractable,
     };
 
-    return Object.assign(json, { x: Convert.ToBase64Url(key) });
+    return Object.assign(json, { x: convert.encode("base64url", key) });
   }
 
   public fromJSON(json: JsonWebKey) {
@@ -38,7 +38,7 @@ export class EdPublicKey extends AsymmetricKey implements IJsonConvertible {
 
     const keyInfo = new core.asn1.PublicKeyInfo();
     keyInfo.publicKeyAlgorithm.algorithm = getOidByNamedCurve(json.crv);
-    keyInfo.publicKey = Convert.FromBase64Url(json.x);
+    keyInfo.publicKey = toArrayBuffer(convert.decode("base64url", json.x));
 
     this.data = Buffer.from(AsnSerializer.serialize(keyInfo));
 

--- a/src/mechs/ed25519/crypto.ts
+++ b/src/mechs/ed25519/crypto.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 import { AsnConvert } from "@peculiar/asn1-schema";
-import { Convert } from "pvtsutils";
+import {
+  assertBufferSource, convert, toArrayBuffer,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { CryptoKey } from "../../keys";
 import { Ed25519CryptoKey } from "./crypto_key";
@@ -55,7 +57,7 @@ export class Ed25519Crypto {
       }
       case "raw": {
         const jwk = key.toJWK();
-        return Convert.FromBase64Url(jwk.x!);
+        return toArrayBuffer(convert.decode("base64url", jwk.x!));
       }
       default:
         return Promise.reject(new core.OperationError("format: Must be 'jwk', 'raw', pkcs8' or 'spki'"));
@@ -69,7 +71,7 @@ export class Ed25519Crypto {
         if (jwk.d) {
           // private key
           const privateData = new core.asn1.EdPrivateKey();
-          privateData.value = core.BufferSourceConverter.toArrayBuffer(Buffer.from(jwk.d, "base64url"));
+          privateData.value = toArrayBuffer(convert.decode("base64url", jwk.d));
           const pkcs8 = new core.asn1.PrivateKeyInfo();
           pkcs8.privateKeyAlgorithm.algorithm = algorithm.name.toLowerCase() === "ed25519"
             ? core.asn1.idEd25519
@@ -93,21 +95,24 @@ export class Ed25519Crypto {
         }
       }
       case "pkcs8": {
-        const pem = core.PemConverter.fromBufferSource(keyData as ArrayBuffer, "PRIVATE KEY");
+        assertBufferSource(keyData);
+        const pem = core.PemConverter.fromBufferSource(toArrayBuffer(keyData), "PRIVATE KEY");
         return new Ed25519PrivateKey(algorithm, extractable, keyUsages, pem);
       }
       case "spki": {
-        const pem = core.PemConverter.fromBufferSource(keyData as ArrayBuffer, "PUBLIC KEY");
+        assertBufferSource(keyData);
+        const pem = core.PemConverter.fromBufferSource(toArrayBuffer(keyData), "PUBLIC KEY");
         return new Ed25519PublicKey(algorithm, extractable, keyUsages, pem);
       }
       case "raw": {
-        const raw = keyData as ArrayBuffer;
+        assertBufferSource(keyData);
+        const raw = toArrayBuffer(keyData);
         const key = crypto.createPublicKey({
           format: "jwk",
           key: {
             kty: "OKP",
             crv: algorithm.name.toLowerCase() === "ed25519" ? "Ed25519" : "X25519",
-            x: Convert.ToBase64Url(raw),
+            x: convert.encode("base64url", raw),
           },
         });
         const pem = key.export({

--- a/src/mechs/hmac/hmac.ts
+++ b/src/mechs/hmac/hmac.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
+import {
+  assertBufferSource, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { ShaCrypto } from "../sha";
 import { setCryptoKey, getCryptoKey } from "../storage";
@@ -25,17 +28,17 @@ export class HmacProvider extends core.HmacProvider {
   public override async onSign(algorithm: Algorithm, key: HmacCryptoKey, data: ArrayBuffer): Promise<ArrayBuffer> {
     const cryptoAlg = ShaCrypto.getAlgorithmName(key.algorithm.hash);
     const hmac = crypto.createHmac(cryptoAlg, getCryptoKey(key).data)
-      .update(Buffer.from(data)).digest();
+      .update(Buffer.from(toUint8Array(data))).digest();
 
-    return new Uint8Array(hmac).buffer;
+    return toArrayBuffer(hmac);
   }
 
   public override async onVerify(algorithm: Algorithm, key: HmacCryptoKey, signature: ArrayBuffer, data: ArrayBuffer): Promise<boolean> {
     const cryptoAlg = ShaCrypto.getAlgorithmName(key.algorithm.hash);
     const hmac = crypto.createHmac(cryptoAlg, getCryptoKey(key).data)
-      .update(Buffer.from(data)).digest();
+      .update(Buffer.from(toUint8Array(data))).digest();
 
-    return hmac.compare(Buffer.from(signature)) === 0;
+    return hmac.compare(Buffer.from(toUint8Array(signature))) === 0;
   }
 
   public async onImportKey(format: KeyFormat, keyData: JsonWebKey | ArrayBuffer, algorithm: HmacImportParams, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey> {
@@ -46,8 +49,9 @@ export class HmacProvider extends core.HmacProvider {
         key = JsonParser.fromJSON(keyData, { targetSchema: HmacCryptoKey });
         break;
       case "raw":
+        assertBufferSource(keyData);
         key = new HmacCryptoKey();
-        key.data = Buffer.from(keyData as ArrayBuffer);
+        key.data = Buffer.from(toUint8Array(keyData));
         break;
       default:
         throw new core.OperationError("format: Must be 'jwk' or 'raw'");
@@ -69,7 +73,7 @@ export class HmacProvider extends core.HmacProvider {
       case "jwk":
         return JsonSerializer.toJSON(getCryptoKey(key));
       case "raw":
-        return new Uint8Array(getCryptoKey(key).data).buffer;
+        return toArrayBuffer(getCryptoKey(key).data);
       default:
         throw new core.OperationError("format: Must be 'jwk' or 'raw'");
     }

--- a/src/mechs/pbkdf/pbkdf2.ts
+++ b/src/mechs/pbkdf/pbkdf2.ts
@@ -1,5 +1,8 @@
 import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
+import {
+  assertBufferSource, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { setCryptoKey, getCryptoKey } from "../storage";
 import { PbkdfCryptoKey } from "./key";
@@ -7,13 +10,13 @@ import { PbkdfCryptoKey } from "./key";
 export class Pbkdf2Provider extends core.Pbkdf2Provider {
   public async onDeriveBits(algorithm: Pbkdf2Params, baseKey: PbkdfCryptoKey, length: number): Promise<ArrayBuffer> {
     return new Promise<ArrayBuffer>((resolve, reject) => {
-      const salt = core.BufferSourceConverter.toArrayBuffer(algorithm.salt);
+      const salt = toUint8Array(algorithm.salt);
       const hash = (algorithm.hash as Algorithm).name.replace("-", "");
       crypto.pbkdf2(getCryptoKey(baseKey).data, Buffer.from(salt), algorithm.iterations, length >> 3, hash, (err, derivedBits) => {
         if (err) {
           reject(err);
         } else {
-          resolve(new Uint8Array(derivedBits).buffer);
+          resolve(toArrayBuffer(derivedBits));
         }
       });
     });
@@ -21,8 +24,9 @@ export class Pbkdf2Provider extends core.Pbkdf2Provider {
 
   public async onImportKey(format: KeyFormat, keyData: JsonWebKey | ArrayBuffer, algorithm: Algorithm, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey> {
     if (format === "raw") {
+      assertBufferSource(keyData);
       const key = new PbkdfCryptoKey();
-      key.data = Buffer.from(keyData as ArrayBuffer);
+      key.data = Buffer.from(toUint8Array(keyData));
       key.algorithm = { name: this.name };
       key.extractable = false;
       key.usages = keyUsages;

--- a/src/mechs/rsa/crypto.ts
+++ b/src/mechs/rsa/crypto.ts
@@ -2,6 +2,9 @@ import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema";
 import { JsonParser, JsonSerializer } from "@peculiar/json-schema";
+import {
+  assertBufferSource, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { CryptoKey } from "../../keys";
 import { RsaPrivateKey } from "./private_key";
@@ -64,7 +67,7 @@ export class RsaCrypto {
         return JsonSerializer.toJSON(key);
       case "pkcs8":
       case "spki":
-        return new Uint8Array(key.data).buffer;
+        return toArrayBuffer(key.data);
       default:
         throw new core.OperationError("format: Must be 'jwk', 'pkcs8' or 'spki'");
     }
@@ -83,12 +86,14 @@ export class RsaCrypto {
         }
       }
       case "spki": {
-        const keyInfo = AsnParser.parse(new Uint8Array(keyData as ArrayBuffer), core.asn1.PublicKeyInfo);
+        assertBufferSource(keyData);
+        const keyInfo = AsnParser.parse(toUint8Array(keyData), core.asn1.PublicKeyInfo);
         const asnKey = AsnParser.parse(keyInfo.publicKey, core.asn1.RsaPublicKey);
         return this.importPublicKey(asnKey, algorithm, extractable, keyUsages);
       }
       case "pkcs8": {
-        const keyInfo = AsnParser.parse(new Uint8Array(keyData as ArrayBuffer), core.asn1.PrivateKeyInfo);
+        assertBufferSource(keyData);
+        const keyInfo = AsnParser.parse(toUint8Array(keyData), core.asn1.PrivateKeyInfo);
         const asnKey = AsnParser.parse(keyInfo.privateKey, core.asn1.RsaPrivateKey);
         return this.importPrivateKey(asnKey, algorithm, extractable, keyUsages);
       }
@@ -207,7 +212,7 @@ export class RsaCrypto {
     }
 
     const signature = signer.sign(options);
-    return new Uint8Array(signature).buffer;
+    return toArrayBuffer(signature);
   }
 
   protected static verifySSA(algorithm: Algorithm, key: RsaPublicKey, data: Uint8Array, signature: Uint8Array) {
@@ -237,7 +242,7 @@ export class RsaCrypto {
       // nothing
     }
 
-    return new Uint8Array(crypto.publicEncrypt(options, data)).buffer;
+    return toArrayBuffer(crypto.publicEncrypt(options, data));
   }
 
   protected static decryptOAEP(algorithm: RsaOaepParams, key: RsaPrivateKey, data: Uint8Array) {
@@ -249,6 +254,6 @@ export class RsaCrypto {
       // nothing
     }
 
-    return new Uint8Array(crypto.privateDecrypt(options, data)).buffer;
+    return toArrayBuffer(crypto.privateDecrypt(options, data));
   }
 }

--- a/src/mechs/rsa/rsa_es.ts
+++ b/src/mechs/rsa/rsa_es.ts
@@ -1,5 +1,7 @@
 import crypto from "node:crypto";
-import { Convert } from "pvtsutils";
+import {
+  convert, toArrayBuffer, toUint8Array,
+} from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { setCryptoKey, getCryptoKey } from "../storage";
 import { RsaCrypto } from "./crypto";
@@ -34,7 +36,7 @@ export class RsaEsProvider extends core.ProviderCrypto {
     if (!(algorithm.publicExponent && algorithm.publicExponent instanceof Uint8Array)) {
       throw new TypeError("publicExponent: Missing or not a Uint8Array");
     }
-    const publicExponent = Convert.ToBase64(algorithm.publicExponent);
+    const publicExponent = convert.encode("base64", algorithm.publicExponent);
     if (!(publicExponent === "Aw==" || publicExponent === "AQAB")) {
       throw new TypeError("publicExponent: Must be [3] or [1,0,1]");
     }
@@ -53,14 +55,14 @@ export class RsaEsProvider extends core.ProviderCrypto {
 
   public override async onEncrypt(algorithm: Algorithm, key: RsaPublicKey, data: ArrayBuffer): Promise<ArrayBuffer> {
     const options = this.toCryptoOptions(key);
-    const enc = crypto.publicEncrypt(options, new Uint8Array(data));
-    return new Uint8Array(enc).buffer;
+    const enc = crypto.publicEncrypt(options, toUint8Array(data));
+    return toArrayBuffer(enc);
   }
 
   public override async onDecrypt(algorithm: Algorithm, key: RsaPrivateKey, data: ArrayBuffer): Promise<ArrayBuffer> {
     const options = this.toCryptoOptions(key);
-    const dec = crypto.privateDecrypt(options, new Uint8Array(data));
-    return new Uint8Array(dec).buffer;
+    const dec = crypto.privateDecrypt(options, toUint8Array(data));
+    return toArrayBuffer(dec);
   }
 
   public override async onExportKey(format: KeyFormat, key: CryptoKey): Promise<JsonWebKey | ArrayBuffer> {

--- a/src/mechs/rsa/rsa_oaep.ts
+++ b/src/mechs/rsa/rsa_oaep.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
+import { toArrayBuffer, toUint8Array } from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { ShaCrypto } from "../sha/crypto";
 import { setCryptoKey, getCryptoKey } from "../storage";
@@ -32,7 +33,7 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
 
   public async onEncrypt(algorithm: RsaOaepParams, key: RsaPublicKey, data: ArrayBuffer): Promise<ArrayBuffer> {
     const internalKey = getCryptoKey(key) as RsaPublicKey;
-    const dataView = new Uint8Array(data);
+    const dataView = toUint8Array(data);
     const keySize = Math.ceil(internalKey.algorithm.modulusLength >> 3);
     const hashSize = ShaCrypto.size(internalKey.algorithm.hash) >> 3;
     const dataLength = dataView.byteLength;
@@ -49,7 +50,7 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
     dataBlock.set(dataView, hashSize + psLength + 1);
 
     const labelHash = crypto.createHash(internalKey.algorithm.hash.name.replace("-", ""))
-      .update(core.BufferSourceConverter.toUint8Array(algorithm.label || new Uint8Array(0)))
+      .update(toUint8Array(algorithm.label || new Uint8Array(0)))
       .digest();
     dataBlock.set(labelHash, 0);
     dataBlock[hashSize + psLength] = 1;
@@ -75,7 +76,7 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
       padding: crypto.constants.RSA_NO_PADDING,
     }, Buffer.from(message));
 
-    return new Uint8Array(pkcs0).buffer;
+    return toArrayBuffer(pkcs0);
   }
 
   public async onDecrypt(algorithm: RsaOaepParams, key: RsaPrivateKey, data: ArrayBuffer): Promise<ArrayBuffer> {
@@ -95,7 +96,7 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
     let pkcs0 = crypto.privateDecrypt({
       key: internalKey.pem,
       padding: crypto.constants.RSA_NO_PADDING,
-    }, Buffer.from(data));
+    }, Buffer.from(toUint8Array(data)));
     const z = pkcs0[0];
     const seed = pkcs0.subarray(1, hashSize + 1);
     const dataBlock = pkcs0.subarray(hashSize + 1);
@@ -115,7 +116,7 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
     }
 
     const labelHash = crypto.createHash(internalKey.algorithm.hash.name.replace("-", ""))
-      .update(core.BufferSourceConverter.toUint8Array(algorithm.label || new Uint8Array(0)))
+      .update(toUint8Array(algorithm.label || new Uint8Array(0)))
       .digest();
     for (let i = 0; i < hashSize; i++) {
       if (labelHash[i] !== dataBlock[i]) {
@@ -139,7 +140,7 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
 
     pkcs0 = dataBlock.subarray(psEnd + 1);
 
-    return new Uint8Array(pkcs0).buffer;
+    return toArrayBuffer(pkcs0);
   }
 
   public async onExportKey(format: KeyFormat, key: CryptoKey): Promise<JsonWebKey | ArrayBuffer> {
@@ -180,10 +181,10 @@ export class RsaOaepProvider extends core.RsaOaepProvider {
 
       const submask = mask.subarray(i * hashSize);
 
-      let chunk = crypto.createHash(algorithm.name.replace("-", ""))
+      let chunk = toUint8Array(crypto.createHash(algorithm.name.replace("-", ""))
         .update(seed)
         .update(counter)
-        .digest() as Uint8Array;
+        .digest());
       if (chunk.length > submask.length) {
         chunk = chunk.subarray(0, submask.length);
       }

--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import nodeCrypto from "node:crypto";
 import process from "node:process";
 import { WebcryptoTest } from "@peculiar/webcrypto-test";
-import { Convert } from "pvtsutils";
+import { convert } from "@peculiar/utils";
 import * as core from "webcrypto-core";
 import { Crypto } from "../src";
 
@@ -219,8 +219,8 @@ describe("Crypto", () => {
             name: "ECDH", public: publicKey,
           } as EcdhKeyDeriveParams, keys.privateKey, 128);
 
-          assert.strictEqual(Convert.ToHex(derivedBits2), Convert.ToHex(derivedBits));
-          assert.strictEqual(Convert.ToHex(derivedBits3), Convert.ToHex(derivedBits));
+          assert.strictEqual(convert.encode("hex", derivedBits2), convert.encode("hex", derivedBits));
+          assert.strictEqual(convert.encode("hex", derivedBits3), convert.encode("hex", derivedBits));
         });
       });
     });
@@ -287,15 +287,15 @@ describe("Crypto", () => {
     const data = new Uint8Array(10);
     it("SHA3-256", async () => {
       const digest = await crypto.subtle.digest("SHA3-256", data);
-      assert.strictEqual(Convert.ToHex(digest), "0cd5285ba8524fe42ac8f0076de9135d056132a9996213ae1c0f1420c908418b");
+      assert.strictEqual(convert.encode("hex", digest), "0cd5285ba8524fe42ac8f0076de9135d056132a9996213ae1c0f1420c908418b");
     });
     it("SHA3-384", async () => {
       const digest = await crypto.subtle.digest("SHA3-384", data);
-      assert.strictEqual(Convert.ToHex(digest), "f54cecb8c160015f87b9e51edd087e10479d60479a42ff7e907ddf129fd7cb2782eb5624c43b453a24cffd8cbe42d0ec");
+      assert.strictEqual(convert.encode("hex", digest), "f54cecb8c160015f87b9e51edd087e10479d60479a42ff7e907ddf129fd7cb2782eb5624c43b453a24cffd8cbe42d0ec");
     });
     it("SHA3-512", async () => {
       const digest = await crypto.subtle.digest("SHA3-512", data);
-      assert.strictEqual(Convert.ToHex(digest), "e12f775adfb4e440b74af7b670849a44b7efd1612a97a3a201080cb31944f1f2d9f0eae6b7c0cdb602f6ff0ba181add9997fd06e43f992df577aa52153ca0d27");
+      assert.strictEqual(convert.encode("hex", digest), "e12f775adfb4e440b74af7b670849a44b7efd1612a97a3a201080cb31944f1f2d9f0eae6b7c0cdb602f6ff0ba181add9997fd06e43f992df577aa52153ca0d27");
     });
   });
 


### PR DESCRIPTION
### Summary
- replace `pvtsutils` with `@peculiar/utils`
- normalize BufferSource handling across crypto providers and key import/export paths
- update tests to use the new converter API
- bump `webcrypto-core` to `^1.9.0`

### Validation
- `npm run test` (232/232 passed)